### PR TITLE
Upgrade example to dash v2.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Dash and dependencies
-RUN pip3 install dash==1.19.0 && \
+RUN pip3 install dash==2.5.1 && \
     pip3 install pandas
 
 RUN mkdir app

--- a/app/app.py
+++ b/app/app.py
@@ -1,12 +1,16 @@
 # from https://dash.plot.ly/getting-started
 import os
-import dash
-import dash_core_components as dcc
-import dash_html_components as html
-import plotly.graph_objs as go
-import pandas as pd
 
-app = dash.Dash()
+import dash
+import pandas as pd
+import plotly.graph_objs as go
+from dash import dcc, html
+
+app = dash.Dash(
+    __name__,
+    suppress_callback_exceptions=True,
+    requests_pathname_prefix=os.environ['SHINYPROXY_PUBLIC_PATH']
+)
 
 df = pd.read_csv(
     'https://gist.githubusercontent.com/chriddyp/' +
@@ -44,13 +48,6 @@ app.layout = html.Div([
     )
 ])
 
-# in order to work on shinyproxy
-# see https://support.openanalytics.eu/t/what-is-the-best-way-of-delivering-static-assets-to-the-client-for-custom-apps/363/5
-app.config.suppress_callback_exceptions = True
-app.config.update({
-    'routes_pathname_prefix': os.environ['SHINYPROXY_PUBLIC_PATH'],
-    'requests_pathname_prefix': os.environ['SHINYPROXY_PUBLIC_PATH']
-})
 
 if __name__ == '__main__':
     app.run_server(debug=True, host = '0.0.0.0')


### PR DESCRIPTION
- Removed parameter routes_pathname_prefix during init of dash.Dash()
- Changed imports of dash.dcc and dcc.html
- Tested with shinyproxy v2.6.1.

I'm currently working on a Plotly Dash (v2.5.1) application and want to deploy it with shinyproxy (v2.6.1).
Therefore, I want to share my solution with you. Feel free to update the demo app if you find my solution useful.

Below are the steps, I ran thorugh:
I cloned this repository and tried to build the docker image with `sudo docker build -t openanalytics/shinyproxy-dash-demo .`

When trying to start a container from this builded image with shinyproxy, I get the following error:
```bash
Traceback (most recent call last):
  File "app.py", line 3, in <module>
    import dash
  File "/usr/local/lib/python3.8/dist-packages/dash/__init__.py", line 5, in <module>
    from .dash import Dash, no_update  # noqa: F401,E402
  File "/usr/local/lib/python3.8/dist-packages/dash/dash.py", line 22, in <module>
    from werkzeug.debug.tbtools import get_current_traceback
ImportError: cannot import name 'get_current_traceback' from 'werkzeug.debug.tbtools' (/usr/local/lib/python3.8/dist-packages/werkzeug/debug/tbtools.py)
```

This led me to the fix in dash version 2.3.1 see [release notes](https://github.com/plotly/dash/releases/tag/v2.3.1).
After upgrading dash dependancy in `Dockerfile` from `dash=1.19.0` to `dash=2.5.1`, the following error occurs during container startup:
```bash
app.py:4: UserWarning:
The dash_core_components package is deprecated. Please replace
`import dash_core_components as dcc` with `from dash import dcc`
  import dash_core_components as dcc
app.py:5: UserWarning:
The dash_html_components package is deprecated. Please replace
`import dash_html_components as html` with `from dash import html`
  import dash_html_components as html
Traceback (most recent call last):
  File "app.py", line 50, in <module>
    app.config.update({
  File "/usr/local/lib/python3.8/dist-packages/dash/_utils.py", line 114, in update
    self[k] = v
  File "/usr/local/lib/python3.8/dist-packages/dash/_utils.py", line 103, in __setitem__
    raise AttributeError(self._read_only[key], key)
AttributeError: ('Read-only: can only be set in the Dash constructor or during init_app()', 'routes_pathname_prefix')
```

So, I changed `app.py` by calling `dash.Dash()` without setting `routes_pathname_prefix`.
